### PR TITLE
[perf]: backport changes from thunder perf hackathon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-Zlinker-features=-lld"] # fix nightly bug https://github.com/rust-lang/rust/issues/125321
+# [target.x86_64-unknown-linux-gnu]
+# rustflags = ["-Zlinker-features=-lld"] # fix nightly bug https://github.com/rust-lang/rust/issues/125321

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +321,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -2858,6 +2864,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -3872,6 +3880,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4125,6 +4143,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5012,6 +5039,7 @@ name = "plain_bitnames"
 version = "0.11.4"
 dependencies = [
  "addr",
+ "ahash",
  "anyhow",
  "async-lock",
  "bech32",
@@ -5028,6 +5056,7 @@ dependencies = [
  "fatality",
  "futures",
  "governor",
+ "hashbrown 0.15.2",
  "hashlink 0.10.0",
  "heed",
  "hex 0.4.3",
@@ -5049,6 +5078,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "sneed",
  "strum 0.26.3",
  "thiserror 2.0.12",
@@ -5086,6 +5116,7 @@ dependencies = [
  "itertools 0.14.0",
  "jsonrpsee",
  "libes",
+ "mimalloc",
  "parking_lot",
  "plain_bitnames",
  "plain_bitnames_app_cli",
@@ -5121,6 +5152,7 @@ dependencies = [
  "hex 0.4.3",
  "http 1.3.1",
  "jsonrpsee",
+ "mimalloc",
  "plain_bitnames",
  "plain_bitnames_app_rpc_api",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,12 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,8 +2858,6 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -5039,7 +5031,6 @@ name = "plain_bitnames"
 version = "0.11.4"
 dependencies = [
  "addr",
- "ahash",
  "anyhow",
  "async-lock",
  "bech32",
@@ -5056,7 +5047,6 @@ dependencies = [
  "fatality",
  "futures",
  "governor",
- "hashbrown 0.15.2",
  "hashlink 0.10.0",
  "heed",
  "hex 0.4.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5152,7 +5152,6 @@ dependencies = [
  "hex 0.4.3",
  "http 1.3.1",
  "jsonrpsee",
- "mimalloc",
  "plain_bitnames",
  "plain_bitnames_app_rpc_api",
  "serde_json",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,7 @@ human-size = "0.4.3"
 itertools = "0.14.0"
 include_path = "0.1.1"
 jsonrpsee = { workspace = true, features = ["server"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 parking_lot = { workspace = true }
 plain_bitnames = { path = "../lib", features = ["clap"] }
 plain_bitnames_app_cli = { path = "../cli" }

--- a/app/app.rs
+++ b/app/app.rs
@@ -33,12 +33,12 @@ use crate::cli::Config;
 pub enum Error {
     #[error(transparent)]
     AmountOverflow(#[from] AmountOverflowError),
+    #[error(transparent)]
+    ComputeMerkleRoot(#[from] plain_bitnames::types::ComputeMerkleRootError),
     #[error("CUSF mainchain proto error")]
     CusfMainchain(#[from] plain_bitnames::types::proto::Error),
     #[error("io error")]
     Io(#[from] std::io::Error),
-    #[error("Failed to compute merkle root")]
-    MerkleRoot,
     #[error("miner error: {0}")]
     Miner(#[from] miner::Error),
     #[error("node error")]
@@ -468,8 +468,8 @@ impl App {
                 .iter()
                 .map(|authorized_tx| authorized_tx.transaction.clone())
                 .collect::<Vec<_>>();
-            Body::compute_merkle_root(&coinbase, &txs)?.ok_or(Error::MerkleRoot)
-        }?;
+            Body::compute_merkle_root(&coinbase, &txs)?
+        };
         let body = {
             let txs = txs.into_iter().map(|tx| tx.into()).collect();
             Body::new(txs, coinbase)

--- a/app/main.rs
+++ b/app/main.rs
@@ -7,8 +7,6 @@ use tokio::{signal::ctrl_c, sync::oneshot};
 use tracing_subscriber::{
     Layer, filter as tracing_filter, layer::SubscriberExt,
 };
-use line_buffer::{LineBuffer, LineBufferWriter};
-use util::saturating_pred_level;
 
 mod app;
 mod cli;
@@ -16,6 +14,9 @@ mod gui;
 mod line_buffer;
 mod rpc_server;
 mod util;
+
+use line_buffer::{LineBuffer, LineBufferWriter};
+use util::saturating_pred_level;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/app/main.rs
+++ b/app/main.rs
@@ -22,18 +22,31 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 fn configure_mimalloc() {
     // Tune mimalloc via environment variables
+    // SAFETY: called before any threads are started, so no other thread can
+    // concurrently read or write the process environment.
     unsafe {
-        env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
-        env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
-        env::set_var("MIMALLOC_ARENA_LIMIT", "4");
-        env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
-        env::set_var("MIMALLOC_EAGER_COMMIT", "1");
-        env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
-        env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
-        env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
-        env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
-        env::set_var("MIMALLOC_PAGE_RESET", "0");
-        env::set_var("MIMALLOC_SEGMENT_RESET", "0");
+        // Limit how many abandoned pages stay cached before returning them to the OS.
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
+        // Reset abandoned pages so their physical memory is released quickly.
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
+        // Cap the number of huge arenas we keep around to bound reserved memory.
+        std::env::set_var("MIMALLOC_ARENA_LIMIT", "4");
+        // Allow mimalloc to allocate from any NUMA node for better balance.
+        std::env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
+        // Commit new pages immediately to avoid first-use page fault latency.
+        std::env::set_var("MIMALLOC_EAGER_COMMIT", "1");
+        // Commit entire regions up front rather than piecemeal to reduce faults.
+        std::env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
+        // Keep up to 32 segments cached for quick reuse before releasing to the OS.
+        std::env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
+        // Prefer allocating from large OS pages (2MB) when the system supports it.
+        std::env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
+        // Reserve a handful of huge OS pages at startup to back large heaps.
+        std::env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
+        // Keep freed pages committed instead of resetting to avoid extra madvise calls.
+        std::env::set_var("MIMALLOC_PAGE_RESET", "0");
+        // Likewise, keep whole segments committed to reduce release/reacquire churn.
+        std::env::set_var("MIMALLOC_SEGMENT_RESET", "0");
     }
 }
 

--- a/app/main.rs
+++ b/app/main.rs
@@ -1,5 +1,5 @@
 #![feature(try_find)]
-use std::{env, path::Path};
+use std::path::Path;
 
 use clap::Parser as _;
 use mimalloc::MiMalloc;

--- a/app/main.rs
+++ b/app/main.rs
@@ -1,14 +1,14 @@
 #![feature(try_find)]
-
-use mimalloc::MiMalloc;
-
 use std::{env, path::Path};
 
 use clap::Parser as _;
+use mimalloc::MiMalloc;
 use tokio::{signal::ctrl_c, sync::oneshot};
 use tracing_subscriber::{
     Layer, filter as tracing_filter, layer::SubscriberExt,
 };
+use line_buffer::{LineBuffer, LineBufferWriter};
+use util::saturating_pred_level;
 
 mod app;
 mod cli;
@@ -16,9 +16,6 @@ mod gui;
 mod line_buffer;
 mod rpc_server;
 mod util;
-
-use line_buffer::{LineBuffer, LineBufferWriter};
-use util::saturating_pred_level;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 http = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 plain_bitnames = { path = "../lib", features = ["clap"] }
 plain_bitnames_app_rpc_api = { path = "../rpc-api" }
 serde_json = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,6 @@ clap = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 http = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client"] }
-mimalloc = { version = "0.1.48", features = ["v3"] }
 plain_bitnames = { path = "../lib", features = ["clap"] }
 plain_bitnames_app_rpc_api = { path = "../rpc-api" }
 serde_json = { workspace = true }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,8 +1,29 @@
 use clap::Parser;
+use mimalloc::MiMalloc;
 use plain_bitnames_app_cli_lib::Cli;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+fn configure_mimalloc() {
+    // Same tuning as the app binary
+    unsafe {
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
+        std::env::set_var("MIMALLOC_ARENA_LIMIT", "4");
+        std::env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
+        std::env::set_var("MIMALLOC_EAGER_COMMIT", "1");
+        std::env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
+        std::env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
+        std::env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
+        std::env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
+        std::env::set_var("MIMALLOC_PAGE_RESET", "0");
+        std::env::set_var("MIMALLOC_SEGMENT_RESET", "0");
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    configure_mimalloc();
     let cli = Cli::parse();
     let res = cli.run().await?;
     #[allow(clippy::print_stdout)]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,29 +1,8 @@
 use clap::Parser;
-use mimalloc::MiMalloc;
 use plain_bitnames_app_cli_lib::Cli;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
-fn configure_mimalloc() {
-    // Same tuning as the app binary
-    unsafe {
-        std::env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
-        std::env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
-        std::env::set_var("MIMALLOC_ARENA_LIMIT", "4");
-        std::env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
-        std::env::set_var("MIMALLOC_EAGER_COMMIT", "1");
-        std::env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
-        std::env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
-        std::env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
-        std::env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
-        std::env::set_var("MIMALLOC_PAGE_RESET", "0");
-        std::env::set_var("MIMALLOC_SEGMENT_RESET", "0");
-    }
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    configure_mimalloc();
     let cli = Cli::parse();
     let res = cli.run().await?;
     #[allow(clippy::print_stdout)]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,6 @@ tonic-build = "0.12.3"
 
 [dependencies]
 addr = "0.15.6"
-ahash = "0.8"
 anyhow = { workspace = true, features = ["backtrace"] }
 async-lock = "3.4.0"
 bech32 = "0.11.0"
@@ -29,7 +28,6 @@ ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 fallible-iterator = "0.3.0"
 fatality = "0.1.1"
 futures = { workspace = true }
-hashbrown = "0.15"
 hashlink = { version = "0.10.0", features = ["serde_impl"] }
 heed = "0.21.0"
 hex = { workspace = true, features = ["serde"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,6 +14,7 @@ tonic-build = "0.12.3"
 
 [dependencies]
 addr = "0.15.6"
+ahash = "0.8"
 anyhow = { workspace = true, features = ["backtrace"] }
 async-lock = "3.4.0"
 bech32 = "0.11.0"
@@ -28,6 +29,7 @@ ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 fallible-iterator = "0.3.0"
 fatality = "0.1.1"
 futures = { workspace = true }
+hashbrown = "0.15"
 hashlink = { version = "0.10.0", features = ["serde_impl"] }
 heed = "0.21.0"
 hex = { workspace = true, features = ["serde"] }
@@ -47,6 +49,7 @@ semver = { version = "1.0.25", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = {  workspace = true }
+smallvec = { version = "1.13.2", features = ["write"] }
 sneed = { version = "0.0.11", features = ["observe"] }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,5 +1,4 @@
 #![feature(impl_trait_in_assoc_type)]
-#![feature(let_chains)]
 #![feature(trait_alias)]
 #![feature(try_find)]
 

--- a/lib/net/error.rs
+++ b/lib/net/error.rs
@@ -14,6 +14,7 @@ pub struct AlreadyConnected(pub SocketAddr);
 /// Another connection can be accepted after a non-fatal error
 #[derive(Transitive)]
 #[fatality(splitable)]
+#[allow(clippy::duplicated_attributes)]
 #[transitive(
     from(db::error::Put, db::Error),
     from(env::error::WriteTxn, env::Error),

--- a/lib/net/peer/error.rs
+++ b/lib/net/peer/error.rs
@@ -120,6 +120,7 @@ pub(in crate::net::peer) mod channel_pool {
     }
 
     #[derive(transitive::Transitive, Debug, Error)]
+    #[allow(clippy::duplicated_attributes)]
     #[transitive(
         from(super::connection::SendHeartbeat, super::connection::SendMessage),
         from(super::connection::SendRequest, super::connection::SendMessage)
@@ -168,6 +169,7 @@ pub(in crate::net::peer) mod request_queue {
     pub struct SendRequest;
 
     #[derive(transitive::Transitive, Debug, Error)]
+    #[allow(clippy::duplicated_attributes)]
     #[transitive(
         from(super::channel_pool::SendMessage, super::channel_pool::Error),
         from(
@@ -177,14 +179,15 @@ pub(in crate::net::peer) mod request_queue {
         from(
             super::channel_pool::SpawnRequestTask,
             super::channel_pool::SpawnTask
-        ),
-        from(super::channel_pool::SpawnTask, super::channel_pool::Error)
+        )
     )]
     pub enum Error {
         #[error(transparent)]
         ChannelPool(#[from] super::channel_pool::Error),
         #[error("Failed to push peer response")]
         PushPeerResponse,
+        #[error(transparent)]
+        SpawnTask(#[from] super::channel_pool::SpawnTask),
     }
 }
 

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -162,7 +162,21 @@ where
                         + MemPool::NUM_DBS
                         + Net::NUM_DBS,
                 );
-            // Apply fast flags consistent with the benchmark setup
+            // Apply LMDB "fast" flags consistent with our benchmark setup:
+            // - WRITE_MAP lets us write directly into the memory map instead of
+            //   copying into LMDB's page buffer, reducing syscall overhead for
+            //   write-heavy workloads.
+            // - MAP_ASYNC hands dirty-page flushing to the kernel so commits do
+            //   not block waiting for msync, keeping latencies tight.
+            // - NO_SYNC and NO_META_SYNC skip fsync calls for data and
+            //   metadata; this trades durability for throughput, which is
+            //   acceptable here because the state can be reconstructed from the
+            //   canonical chain if a crash occurs.
+            // - NO_READ_AHEAD disables kernel readahead that would otherwise
+            //   touch cold pages we immediately overwrite, improving random
+            //   access behaviour on SSDs used in testing.
+            // - NO_TLS stops LMDB from relying on thread-local storage for
+            //   reader slots so transactions can be moved across Tokio tasks.
             let fast_flags = EnvFlags::WRITE_MAP
                 | EnvFlags::MAP_ASYNC
                 | EnvFlags::NO_SYNC

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     state::{self, State},
     types::{
-        BmmResult, Body, Header, MerkleRoot, Tip,
+        BmmResult, Body, Header, Tip,
         proto::{self, mainchain},
     },
     util::join_set,
@@ -138,15 +138,13 @@ fn connect_tip_(
     two_way_peg_data: &mainchain::TwoWayPegData,
 ) -> Result<(), Error> {
     let block_hash = header.hash();
-    let (_fees, merkle_root): (bitcoin::Amount, MerkleRoot) =
-        state.validate_block(rwtxn, header, body)?;
     if tracing::enabled!(tracing::Level::DEBUG) {
         let height = state.try_get_height(rwtxn)?;
-        let _: MerkleRoot = state.connect_block(rwtxn, header, body)?;
-        tracing::debug!(?height, %merkle_root, %block_hash,
+        let () = state.apply_block(rwtxn, header, body)?;
+        tracing::debug!(?height, %block_hash,
                             "connected body")
     } else {
-        let _: MerkleRoot = state.connect_block(rwtxn, header, body)?;
+        let () = state.apply_block(rwtxn, header, body)?;
     }
     let () = state.connect_two_way_peg_data(rwtxn, two_way_peg_data)?;
     let () = archive.put_header(rwtxn, header)?;

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -11,6 +11,7 @@ use crate::types::{
 
 /// Errors related to BitNames
 #[derive(Debug, Error, Transitive)]
+#[allow(clippy::duplicated_attributes)]
 #[transitive(from(db::Delete, db::Error))]
 #[transitive(from(db::Last, db::Error))]
 #[transitive(from(db::Put, db::Error))]
@@ -54,6 +55,7 @@ pub enum InvalidHeader {
 }
 
 #[derive(Debug, Error, Transitive)]
+#[allow(clippy::duplicated_attributes)]
 #[transitive(from(db::Clear, db::Error))]
 #[transitive(from(db::Delete, db::Error))]
 #[transitive(from(db::Error, sneed::Error))]
@@ -84,6 +86,8 @@ pub enum Error {
     BundleTooHeavy { weight: u64, max_weight: u64 },
     #[error(transparent)]
     BorshSerialize(borsh::io::Error),
+    #[error(transparent)]
+    ComputeMerkleRoot(#[from] crate::types::ComputeMerkleRootError),
     #[error(transparent)]
     Db(#[from] sneed::Error),
     #[error("failed to fill tx output contents: invalid transaction")]

--- a/lib/types/hashes.rs
+++ b/lib/types/hashes.rs
@@ -296,3 +296,31 @@ where
         .expect("failed to serialize with borsh to compute a hash");
     blake3::hash(&data_serialized).into()
 }
+
+/// Optimized hash function that reuses a thread-local scratch buffer
+/// to avoid heap allocations for each hash operation.
+/// This provides significant performance benefits when hashing many small objects.
+pub fn hash_with_scratch_buffer<T>(data: &T) -> Hash
+where
+    T: BorshSerialize + ?Sized,
+{
+    use smallvec::SmallVec;
+
+    thread_local! {
+        // Thread-local scratch buffer that starts with 256 bytes on the stack
+        // and grows as needed. This avoids heap allocations for most transactions.
+        static SCRATCH_BUFFER: std::cell::RefCell<SmallVec<[u8; 256]>> =
+            std::cell::RefCell::new(SmallVec::new());
+    }
+
+    SCRATCH_BUFFER.with(|buffer| {
+        let mut buffer = buffer.borrow_mut();
+        buffer.clear(); // Reuse the buffer
+
+        // Serialize directly into the reused buffer
+        borsh::to_writer(&mut *buffer, data)
+            .expect("failed to serialize with borsh to compute a hash");
+
+        blake3::hash(&buffer).into()
+    })
+}

--- a/lib/types/hashes.rs
+++ b/lib/types/hashes.rs
@@ -94,6 +94,7 @@ impl utoipa::ToSchema for BlockHash {
 
 #[derive(
     BorshSerialize,
+    BorshDeserialize,
     Clone,
     Copy,
     Default,
@@ -149,6 +150,7 @@ impl utoipa::ToSchema for MerkleRoot {
 
 #[derive(
     BorshSerialize,
+    BorshDeserialize,
     Clone,
     Copy,
     Default,

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -34,8 +34,8 @@ pub use transaction::{
     Authorized, AuthorizedTransaction, BatchIcannRegistrationData,
     BitcoinOutputContent, Content as OutputContent,
     FilledContent as FilledOutputContent, FilledOutput, FilledTransaction,
-    InPoint, OutPoint, Output, Pointed as PointedOutput, SpentOutput,
-    Transaction, TransactionData, TxData, WithdrawalOutputContent,
+    InPoint, OutPoint, OutPointKey, Output, Pointed as PointedOutput,
+    SpentOutput, Transaction, TransactionData, TxData, WithdrawalOutputContent,
 };
 
 pub const THIS_SIDECHAIN: u8 = 2;
@@ -47,6 +47,43 @@ pub struct AmountOverflowError;
 #[derive(Debug, Error)]
 #[error("Bitcoin amount underflow")]
 pub struct AmountUnderflowError;
+
+#[derive(Debug, Error)]
+pub enum ComputeMerkleRootError {
+    #[error("Fee computation failed for transaction {txid}: {source}")]
+    FeeComputation {
+        txid: Txid,
+        #[source]
+        source: GetFeeError,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum GetFeeError {
+    #[error("Amount overflow")]
+    AmountOverflow,
+    #[error("Amount underflow")]
+    AmountUnderflow,
+}
+
+// Helper module for serializing bitcoin::Amount with Borsh
+mod borsh_bitcoin_amount {
+    use bitcoin::Amount;
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    pub fn serialize<W: borsh::io::Write>(
+        amount: &Amount,
+        writer: &mut W,
+    ) -> borsh::io::Result<()> {
+        amount.to_sat().serialize(writer)
+    }
+
+    #[allow(dead_code)]
+    pub fn deserialize(buf: &mut &[u8]) -> borsh::io::Result<Amount> {
+        let sats = u64::deserialize(buf)?;
+        Ok(Amount::from_sat(sats))
+    }
+}
 
 /// (de)serialize as Display/FromStr for human-readable forms like json,
 /// and default serialization for non human-readable forms like bincode
@@ -287,11 +324,12 @@ pub struct TwoWayPegData {
 }
 
 // Internal node of a CBMT
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, BorshSerialize)]
 struct CbmtNode {
     // Commitment to child nodes or leaf value
     commitment: Hash,
     // Sum of fees for child nodes or leaf value
+    #[borsh(serialize_with = "borsh_bitcoin_amount::serialize")]
     fees: bitcoin::Amount,
     // Sum of canonical tx sizes for child nodes or leaf value
     canonical_size: u64,
@@ -315,6 +353,25 @@ impl Ord for CbmtNode {
 // Marker type for merging branch commitments with
 // * branch fee totals
 // * branch canonical size totals
+/// Hash to get a [`CbmtNode`] inner commitment for a leaf value
+#[derive(Debug, BorshSerialize)]
+struct CbmtLeafPreCommitment<'a> {
+    #[borsh(serialize_with = "borsh_bitcoin_amount::serialize")]
+    fee: bitcoin::Amount,
+    canonical_size: u64,
+    tx: &'a Transaction,
+}
+
+/// Hash to get a [`CbmtNode`] inner commitment for an internal node
+#[derive(Debug, BorshSerialize)]
+struct CbmtNodePreCommitment {
+    left_commitment: Hash,
+    #[borsh(serialize_with = "borsh_bitcoin_amount::serialize")]
+    fees: bitcoin::Amount,
+    canonical_size: u64,
+    right_commitment: Hash,
+}
+
 struct MergeFeeSizeTotal;
 
 impl merkle_cbt::merkle_tree::Merge for MergeFeeSizeTotal {
@@ -326,12 +383,13 @@ impl merkle_cbt::merkle_tree::Merge for MergeFeeSizeTotal {
         // see https://github.com/nervosnetwork/merkle-tree/blob/5d1898263e7167560fdaa62f09e8d52991a1c712/README.md#tree-struct
         assert_eq!(lnode.index + 1, rnode.index);
         let index = (lnode.index - 1) / 2;
-        let commitment = hashes::hash(&(
-            lnode.commitment,
-            rnode.commitment,
-            fees.to_sat(),
-            canonical_size,
-        ));
+        let commitment =
+            hashes::hash_with_scratch_buffer(&CbmtNodePreCommitment {
+                left_commitment: lnode.commitment,
+                fees,
+                canonical_size,
+                right_commitment: rnode.commitment,
+            });
         Self::Item {
             commitment,
             fees,
@@ -396,37 +454,119 @@ impl Body {
     pub fn compute_merkle_root(
         coinbase: &[Output],
         txs: &[FilledTransaction],
-    ) -> Result<Option<MerkleRoot>, AmountOverflowError> {
+    ) -> Result<MerkleRoot, ComputeMerkleRootError> {
         let CbmtNode {
             commitment: txs_root,
             ..
         } = {
             let n_txs = txs.len();
-            let Some(leaves) = txs
-                .iter()
+
+            // Pre-allocate Vec for direct indexing by parallel threads
+            let mut leaves = vec![CbmtNode::default(); n_txs];
+
+            // Use Rayon to compute leaves in parallel across all CPU cores
+            use rayon::prelude::*;
+            let results: Result<Vec<_>, ComputeMerkleRootError> = txs
+                .par_iter()
                 .enumerate()
                 .map(|(idx, tx)| {
-                    let Some(fees) = tx.fee()? else {
-                        return Ok(None);
+                    let fees = tx.get_fee().map_err(|err| {
+                        ComputeMerkleRootError::FeeComputation {
+                            txid: tx.transaction.txid(),
+                            source: err,
+                        }
+                    })?;
+                    let canonical_size = tx.transaction.canonical_size();
+                    let leaf_pre_commitment = CbmtLeafPreCommitment {
+                        fee: fees,
+                        canonical_size,
+                        tx: &tx.transaction,
                     };
-                    Ok(Some(CbmtNode {
-                        commitment: hashes::hash(&tx.transaction),
+                    let node = CbmtNode {
+                        commitment: hashes::hash_with_scratch_buffer(
+                            &leaf_pre_commitment,
+                        ),
                         fees,
-                        canonical_size: tx.transaction.canonical_size(),
+                        canonical_size,
                         // see https://github.com/nervosnetwork/merkle-tree/blob/5d1898263e7167560fdaa62f09e8d52991a1c712/README.md#tree-struct
                         index: (idx + n_txs) - 1,
-                    }))
+                    };
+                    Ok((idx, node))
                 })
-                .collect::<Result<Option<Vec<_>>, _>>()?
-            else {
-                return Ok(None);
-            };
-            CbmtWithFeeTotal::build_merkle_root(leaves.as_slice())
+                .collect();
+
+            // Fill the pre-allocated vector with computed nodes
+            for (idx, node) in results? {
+                leaves[idx] = node;
+            }
+
+            // Replace tree-based CBMT with parallel levelized approach for better performance
+            if n_txs >= 1000 {
+                // Use optimized parallel level merging for large transaction sets
+                Self::compute_merkle_root_levelized_parallel(leaves)
+            } else {
+                // Use original CBMT for smaller sets
+                CbmtWithFeeTotal::build_merkle_root(leaves.as_slice())
+            }
         };
         // FIXME: Compute actual merkle root instead of just a hash.
+        let coinbase_root = hashes::hash(&coinbase);
         // TODO: Should this include `total_fees`?
-        let root = hashes::hash(&(coinbase, txs_root)).into();
-        Ok(Some(root))
+        let root = hashes::hash(&(coinbase_root, txs_root)).into();
+        Ok(root)
+    }
+
+    /// Optimized level-by-level parallel merkle tree construction
+    /// Processes each level of the tree in parallel for maximum performance
+    fn compute_merkle_root_levelized_parallel(
+        mut current_level: Vec<CbmtNode>,
+    ) -> CbmtNode {
+        use rayon::prelude::*;
+
+        while current_level.len() > 1 {
+            // Handle odd number of nodes by duplicating the last node (standard merkle tree approach)
+            if current_level.len() % 2 == 1 {
+                let last_node = current_level.last().unwrap().clone();
+                current_level.push(last_node);
+            }
+
+            // Process pairs of nodes in parallel across all CPU cores
+            current_level = current_level
+                .par_chunks_exact(2)
+                .enumerate()
+                .map(|(parent_idx, pair)| {
+                    let lnode = &pair[0];
+                    let rnode = &pair[1];
+
+                    // Compute parent node using the same merge logic as MergeFeeSizeTotal
+                    let fees = lnode.fees + rnode.fees;
+                    let canonical_size =
+                        lnode.canonical_size + rnode.canonical_size;
+
+                    let commitment = hashes::hash_with_scratch_buffer(
+                        &CbmtNodePreCommitment {
+                            left_commitment: lnode.commitment,
+                            fees,
+                            canonical_size,
+                            right_commitment: rnode.commitment,
+                        },
+                    );
+
+                    CbmtNode {
+                        commitment,
+                        fees,
+                        canonical_size,
+                        index: parent_idx,
+                    }
+                })
+                .collect();
+        }
+
+        // Return the root node
+        current_level
+            .into_iter()
+            .next()
+            .expect("Tree should have exactly one root")
     }
 
     pub fn get_inputs(&self) -> Vec<OutPoint> {
@@ -442,10 +582,8 @@ impl Body {
         txs: &[FilledTransaction],
     ) -> Result<Option<HashMap<OutPoint, Output>>, AmountOverflowError> {
         let mut outputs = HashMap::new();
-        let Some(merkle_root) = Self::compute_merkle_root(coinbase, txs)?
-        else {
-            return Ok(None);
-        };
+        let merkle_root = Self::compute_merkle_root(coinbase, txs)
+            .map_err(|_| AmountOverflowError)?;
         for (vout, output) in coinbase.iter().enumerate() {
             let vout = vout as u32;
             let outpoint = OutPoint::Coinbase { merkle_root, vout };

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -510,9 +510,10 @@ impl Body {
             }
         };
         // FIXME: Compute actual merkle root instead of just a hash.
-        let coinbase_root = hashes::hash(&coinbase);
+        let coinbase_root = hashes::hash_with_scratch_buffer(&coinbase);
         // TODO: Should this include `total_fees`?
-        let root = hashes::hash(&(coinbase_root, txs_root)).into();
+        let root =
+            hashes::hash_with_scratch_buffer(&(coinbase_root, txs_root)).into();
         Ok(root)
     }
 

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -1,5 +1,7 @@
+use std::io::Cursor;
+
 use bitcoin::amount::CheckedSum;
-use borsh::BorshSerialize;
+use borsh::{self, BorshDeserialize, BorshSerialize};
 use heed::{BoxedError, BytesDecode, BytesEncode};
 use serde::{Deserialize, Serialize};
 use utoipa::{PartialSchema, ToSchema};
@@ -33,8 +35,24 @@ where
     borsh::BorshSerialize::serialize(&(txid_bytes, vout), writer)
 }
 
+fn borsh_deserialize_bitcoin_outpoint<R>(
+    reader: &mut R,
+) -> borsh::io::Result<bitcoin::OutPoint>
+where
+    R: borsh::io::Read,
+{
+    use bitcoin::hashes::Hash as _;
+    let (txid_bytes, vout): ([u8; 32], u32) =
+        <([u8; 32], u32) as BorshDeserialize>::deserialize_reader(reader)?;
+    Ok(bitcoin::OutPoint {
+        txid: bitcoin::Txid::from_byte_array(txid_bytes),
+        vout,
+    })
+}
+
 #[derive(
     BorshSerialize,
+    BorshDeserialize,
     Clone,
     Copy,
     Debug,
@@ -61,7 +79,10 @@ pub enum OutPoint {
     // Created by mainchain deposits.
     #[schema(value_type = crate::types::schema::BitcoinOutPoint)]
     Deposit(
-        #[borsh(serialize_with = "borsh_serialize_bitcoin_outpoint")]
+        #[borsh(
+            serialize_with = "borsh_serialize_bitcoin_outpoint",
+            deserialize_with = "borsh_deserialize_bitcoin_outpoint"
+        )]
         bitcoin::OutPoint,
     ),
 }
@@ -80,75 +101,36 @@ impl std::fmt::Display for OutPoint {
     }
 }
 
-/// Fixed-width lexicographically sortable key for OutPoint
-/// Layout: [tag: u8][id: 32][vout: u32 BE]
-/// - tag: 0 = Regular, 1 = Coinbase, 2 = Deposit
-/// - id: txid/merkle_root/bitcoin::txid
-/// - vout: big-endian for numeric order = lexicographic order
+const OUTPOINT_KEY_SIZE: usize = 37;
+
+/// Fixed-width key for OutPoint based on its canonical Borsh encoding.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct OutPointKey([u8; 37]);
+pub struct OutPointKey([u8; OUTPOINT_KEY_SIZE]);
 
 impl OutPointKey {
-    /// Encode an OutPoint into a fixed-width lexicographically sortable key
-    #[inline]
-    pub fn from_outpoint(op: &OutPoint) -> Self {
-        let mut k = [0u8; 37];
-        match *op {
-            OutPoint::Regular {
-                txid: Txid(id),
-                vout,
-            } => {
-                k[0] = 0;
-                k[1..33].copy_from_slice(&id);
-                k[33..37].copy_from_slice(&vout.to_be_bytes());
-            }
-            OutPoint::Coinbase { merkle_root, vout } => {
-                k[0] = 1;
-                let id: Hash = merkle_root.into();
-                k[1..33].copy_from_slice(&id);
-                k[33..37].copy_from_slice(&vout.to_be_bytes());
-            }
-            OutPoint::Deposit(ref bop) => {
-                k[0] = 2;
-                k[1..33].copy_from_slice(bop.txid.as_ref());
-                k[33..37].copy_from_slice(&bop.vout.to_be_bytes());
-            }
-        }
-        Self(k)
-    }
-
     /// Get the raw key bytes
     #[inline]
-    pub fn as_bytes(&self) -> &[u8; 37] {
+    pub fn as_bytes(&self) -> &[u8; OUTPOINT_KEY_SIZE] {
         &self.0
     }
 
     /// Decode OutPointKey back to OutPoint
     #[inline]
     pub fn to_outpoint(&self) -> OutPoint {
-        let tag = self.0[0];
-        let mut id = [0u8; 32];
-        id.copy_from_slice(&self.0[1..33]);
-        let vout = u32::from_be_bytes([
-            self.0[33], self.0[34], self.0[35], self.0[36],
-        ]);
+        let mut cursor = Cursor::new(&self.0[..]);
+        OutPoint::deserialize_reader(&mut cursor)
+            .expect("OutPointKey stores canonical Borsh-serialized OutPoints")
+    }
 
-        match tag {
-            0 => OutPoint::Regular {
-                txid: Txid(id),
-                vout,
-            },
-            1 => OutPoint::Coinbase {
-                merkle_root: MerkleRoot::from(Hash::from(id)),
-                vout,
-            },
-            2 => {
-                use bitcoin::hashes::Hash as BitcoinHash;
-                let txid = bitcoin::Txid::from_byte_array(id);
-                OutPoint::Deposit(bitcoin::OutPoint { txid, vout })
-            }
-            _ => unreachable!("Invalid OutPointKey tag"),
-        }
+    /// Encode an OutPoint into a fixed-width key
+    #[inline]
+    pub fn from_outpoint(op: &OutPoint) -> Self {
+        let mut key = [0u8; OUTPOINT_KEY_SIZE];
+        let mut cursor = Cursor::new(&mut key[..]);
+        BorshSerialize::serialize(op, &mut cursor)
+            .expect("serializing OutPoint into key buffer should never fail");
+        debug_assert_eq!(cursor.position() as usize, OUTPOINT_KEY_SIZE);
+        Self(key)
     }
 }
 
@@ -218,12 +200,54 @@ impl<'a> BytesDecode<'a> for OutPointKey {
 
     #[inline]
     fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
-        if bytes.len() != 37 {
+        if bytes.len() != OUTPOINT_KEY_SIZE {
             return Err("OutPointKey must be exactly 37 bytes".into());
         }
-        let mut key = [0u8; 37];
+        let mut key = [0u8; OUTPOINT_KEY_SIZE];
         key.copy_from_slice(bytes);
+        let mut cursor = Cursor::new(&key[..]);
+        OutPoint::deserialize_reader(&mut cursor)
+            .map_err(|err| -> BoxedError { Box::new(err) })?;
         Ok(OutPointKey(key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OUTPOINT_KEY_SIZE, OutPoint, OutPointKey};
+
+    #[test]
+    fn check_outpoint_key_size() -> anyhow::Result<()> {
+        use bitcoin::hashes::Hash as _;
+
+        let variants = [
+            OutPoint::Regular {
+                txid: Default::default(),
+                vout: u32::MAX,
+            },
+            OutPoint::Coinbase {
+                merkle_root: Default::default(),
+                vout: u32::MAX,
+            },
+            OutPoint::Deposit(bitcoin::OutPoint {
+                txid: bitcoin::Txid::from_byte_array([0; 32]),
+                vout: u32::MAX,
+            }),
+        ];
+
+        for op in variants {
+            let serialized = borsh::to_vec(&op)?;
+            anyhow::ensure!(
+                serialized.len() == OUTPOINT_KEY_SIZE,
+                "unexpected serialized size: {}",
+                serialized.len()
+            );
+
+            let key = OutPointKey::from(op);
+            let decoded = OutPoint::from(key);
+            anyhow::ensure!(decoded == op);
+        }
+        Ok(())
     }
 }
 

--- a/lib/types/transaction/mod.rs
+++ b/lib/types/transaction/mod.rs
@@ -144,7 +144,7 @@ impl From<OutPoint> for OutPointKey {
 impl From<&OutPoint> for OutPointKey {
     #[inline]
     fn from(op: &OutPoint) -> Self {
-        Self::from_outpoint(op)
+        <Self as From<OutPoint>>::from(*op)
     }
 }
 
@@ -158,7 +158,7 @@ impl From<OutPointKey> for OutPoint {
 impl From<&OutPointKey> for OutPoint {
     #[inline]
     fn from(key: &OutPointKey) -> Self {
-        key.to_outpoint()
+        <Self as From<OutPointKey>>::from(*key)
     }
 }
 

--- a/lib/util.rs
+++ b/lib/util.rs
@@ -115,7 +115,7 @@ pub use watchable::Watchable;
 /// Display an error with causes.
 /// This is useful for displaying errors without converting to
 /// `miette::Report` or `anyhow::Error` first
-pub struct ErrorChain<'a>(&'a (dyn std::error::Error));
+pub struct ErrorChain<'a>(&'a dyn std::error::Error);
 
 impl<'a> ErrorChain<'a> {
     pub fn new<E>(err: &'a E) -> Self

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -15,7 +15,7 @@ use heed::{
     types::{Bytes, SerdeBincode, Str, U8, U32},
 };
 use libes::EciesError;
-use rayon::prelude::*;
+use rayon::prelude::ParallelSliceMut;
 use serde::{Deserialize, Serialize};
 use sneed::{DbError, Env, EnvError, RwTxnError, UnitKey, db, env, rwtxn};
 use thiserror::Error;


### PR DESCRIPTION
This PR adds misc perf improvements which have been already merged (or partially merged) into upstream. This includes

* Prevalidate + connect + apply in single RW txn:
* LMDB env fast flags in node init (`WRITE_MAP, MAP_ASYNC, NO_SYNC, NO_META_SYNC, NO_READ_AHEAD, NO_TLS`)
* Vec + parallel sort over `OutPointKey` and ordered apply to coalesce writes
* Fixed-width `OutPointKey keys` for LMDB (both node and wallet DBs)
* Double-spend detection via parallel sort of fixed-width keys
* Vector preallocations / more rayon usage
* Switch to `mimalloc` v3 as a global allocator
* Scratch-buffer hashing on hot call sites
* Threshold based parallel merging over levels for large transaction sets on merkle tree building