### PR TITLE
Reject blocks and transactions with the wrong number of authorizations

### DIFF
--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -84,6 +84,21 @@ pub fn validate(
         };
         return Err(err);
     }
+    // The authorization and address checks below pair authorizations with
+    // spent UTXOs positionally via `zip`, which silently ignores any trailing
+    // inputs when there are fewer authorizations than inputs requiring one.
+    // Require an exact count so that every input requiring authorization is
+    // covered by a provided authorization.
+    let n_authorizations_required: usize = filled_txs
+        .iter()
+        .map(|t| t.spent_utxos_requiring_auth().len())
+        .sum();
+    if body.authorizations.len() != n_authorizations_required {
+        return Err(Error::WrongNumberOfAuthorizations {
+            expected: n_authorizations_required,
+            received: body.authorizations.len(),
+        });
+    }
     let spent_utxos = filled_txs
         .iter()
         .flat_map(|t| t.spent_utxos_requiring_auth().into_iter());
@@ -167,6 +182,21 @@ pub fn prevalidate(
             computed: computed_merkle_root,
         };
         return Err(err);
+    }
+    // The authorization and address checks below pair authorizations with
+    // spent UTXOs positionally via `zip`, which silently ignores any trailing
+    // inputs when there are fewer authorizations than inputs requiring one.
+    // Require an exact count so that every input requiring authorization is
+    // covered by a provided authorization.
+    let n_authorizations_required: usize = filled_transactions
+        .iter()
+        .map(|t| t.spent_utxos_requiring_auth().len())
+        .sum();
+    if body.authorizations.len() != n_authorizations_required {
+        return Err(Error::WrongNumberOfAuthorizations {
+            expected: n_authorizations_required,
+            received: body.authorizations.len(),
+        });
     }
     let spent_utxos = filled_transactions
         .iter()

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -265,6 +265,10 @@ pub enum Error {
     UtxoDoubleSpent,
     #[error(transparent)]
     WithdrawalBundle(#[from] WithdrawalBundleError),
+    #[error(
+        "wrong number of authorizations: expected {expected}, but received {received}"
+    )]
+    WrongNumberOfAuthorizations { expected: usize, received: usize },
     #[error("wrong public key for address")]
     WrongPubKeyForAddress,
 }

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -661,3 +661,111 @@ impl Watchable<()> for State {
         tokio_stream::wrappers::WatchStream::new(self.tip.watch().clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::SigningKey;
+
+    use super::{Error, State};
+    use crate::{
+        authorization,
+        types::{
+            Address, AuthorizedTransaction, BitcoinOutputContent, FilledOutput,
+            FilledOutputContent, OutPoint, OutPointKey, Output, OutputContent,
+            Transaction, VerifyingKey,
+        },
+    };
+
+    /// Open a fresh state in a unique temporary directory.
+    fn new_state() -> (sneed::Env, State) {
+        let path = std::env::temp_dir()
+            .join(format!("plain_bitnames_auth_count_{}", std::process::id()));
+        let _remove_result = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        let env = {
+            let mut opts = heed::EnvOpenOptions::new();
+            opts.map_size(10 * 1024 * 1024).max_dbs(State::NUM_DBS);
+            unsafe { sneed::Env::open(&opts, &path) }.unwrap()
+        };
+        let state = State::new(&env).unwrap();
+        (env, state)
+    }
+
+    /// Fund `address` with a single bitcoin UTXO of `value` sats, returning its
+    /// outpoint.
+    fn fund(
+        env: &sneed::Env,
+        state: &State,
+        address: Address,
+        value: u64,
+    ) -> OutPoint {
+        let outpoint = OutPoint::Regular {
+            txid: Default::default(),
+            vout: 0,
+        };
+        let output = FilledOutput::new(
+            address,
+            FilledOutputContent::Bitcoin(BitcoinOutputContent(
+                bitcoin::Amount::from_sat(value),
+            )),
+        );
+        let mut rwtxn = env.write_txn().unwrap();
+        state
+            .utxos
+            .put(&mut rwtxn, &OutPointKey::from(&outpoint), &output)
+            .unwrap();
+        rwtxn.commit().unwrap();
+        outpoint
+    }
+
+    /// A transaction that spends an input without supplying an authorization
+    /// for it must be rejected. Otherwise the `zip` of authorizations and
+    /// spent UTXOs silently skips the unauthorized input, allowing any UTXO to
+    /// be spent without a signature.
+    #[test]
+    fn validate_transaction_rejects_missing_authorization() {
+        let (env, state) = new_state();
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let verifying_key: VerifyingKey = signing_key.verifying_key().into();
+        let address = authorization::get_address(&verifying_key);
+        let outpoint = fund(&env, &state, address, 1000);
+
+        let transaction = Transaction::new(
+            vec![outpoint],
+            vec![Output::new(
+                address,
+                OutputContent::Bitcoin(BitcoinOutputContent(
+                    bitcoin::Amount::from_sat(900),
+                )),
+            )],
+        );
+
+        // The attack: spend the input while providing no authorization for it.
+        let unauthorized = AuthorizedTransaction {
+            transaction: transaction.clone(),
+            authorizations: Vec::new(),
+        };
+        let rotxn = env.read_txn().unwrap();
+        let err = state
+            .validate_transaction(&rotxn, &unauthorized)
+            .expect_err("tx with no authorizations must be rejected");
+        assert!(
+            matches!(
+                err,
+                Error::WrongNumberOfAuthorizations {
+                    expected: 1,
+                    received: 0
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+
+        // The same transaction with a valid authorization is accepted.
+        let authorized =
+            authorization::authorize(&[(address, &signing_key)], transaction)
+                .unwrap();
+        state
+            .validate_transaction(&rotxn, &authorized)
+            .expect("correctly authorized tx should validate");
+    }
+}

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -484,6 +484,17 @@ impl State {
     ) -> Result<bitcoin::Amount, Error> {
         let filled_transaction =
             self.fill_transaction(rotxn, &transaction.transaction)?;
+        // Pairing authorizations with spent UTXOs via `zip` silently ignores
+        // trailing inputs when there are too few authorizations. Require an
+        // exact count so that every input requiring authorization is covered.
+        let n_authorizations_required =
+            filled_transaction.spent_utxos_requiring_auth().len();
+        if transaction.authorizations.len() != n_authorizations_required {
+            return Err(Error::WrongNumberOfAuthorizations {
+                expected: n_authorizations_required,
+                received: transaction.authorizations.len(),
+            });
+        }
         for (authorization, spent_utxo) in transaction
             .authorizations
             .iter()


### PR DESCRIPTION
Authorizations were paired with inputs positionally via `zip`, with no check that the two counts match. Because `zip` stops at the shorter iterator, supplying *fewer* authorizations than there are inputs requiring one left the surplus inputs completely unverified, both the address check and the signature check simply skipped them.

This allowed any UTXO to be spent without a valid signature. In the extreme case, a transaction (or whole block body) with **zero** authorizations passes validation: the address-check `zip` and the batch signature verification both run over empty input sets and succeed. Since the block `Header` commits only to the merkle root (which does not cover authorizations), a single crafted block could spend arbitrary UTXOs  i.e. steal any funds on the chain.

## Fix

Enforce an exact authorization count at all three validation entry points, before the existing `zip`-based address/signature checks:

- `block::validate` — block validation
- `block::prevalidate` — the path `apply_block` actually uses when connecting
- `State::validate_transaction` — mempool admission

The required count is computed from `spent_utxos_requiring_auth()` rather than the raw input count, so legitimate batch-ICANN transactions which intentionally carry fewer authorizations than inputs still validate. A new `Error::WrongNumberOfAuthorizations { expected, received }` variant is returned on mismatch.

## Test

Adds `validate_transaction_rejects_missing_authorization`, which funds an address, then attempts to spend the UTXO with an empty authorization list and asserts it is rejected with `WrongNumberOfAuthorizations { expected: 1, received: 0 }`. It also confirms the same transaction validates once a correct
authorization is supplied.

Verified the test fails against the unpatched code (the unauthorized spend is accepted and returns a fee of 100 sat) and passes with the fix applied.