### PR TITLE
Do not let an invalid peer block take the node offline

### DIFF
--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -256,6 +256,11 @@ fn disconnect_tip_(
     Ok(())
 }
 
+// peer-caused state errors must not be fatal
+fn is_fatal_reorg_error(err: &Error) -> bool {
+    !matches!(err, Error::State(_))
+}
+
 /// Re-org to the specified tip, if it is better than the current tip.
 /// The new tip block and all ancestor blocks must exist in the node's archive.
 /// A result of `Ok(true)` indicates a successful re-org.
@@ -1022,8 +1027,8 @@ impl NetTask {
                         }
                     }
                 }
-                MailboxItem::NewTipReady(new_tip, _addr, resp_tx) => {
-                    let reorg_applied = task::block_in_place(|| {
+                MailboxItem::NewTipReady(new_tip, addr, resp_tx) => {
+                    let reorg_result = task::block_in_place(|| {
                         reorg_to_tip(
                             &self.ctxt.env,
                             &self.ctxt.archive,
@@ -1033,7 +1038,26 @@ impl NetTask {
                             &self.ctxt.zmq_pub_handler,
                             new_tip,
                         )
-                    })?;
+                    });
+                    let reorg_applied = match reorg_result {
+                        Ok(applied) => applied,
+                        Err(err) if is_fatal_reorg_error(&err) => {
+                            return Err(err);
+                        }
+                        // invalid block: drop the peer, keep running
+                        Err(err) => {
+                            tracing::warn!(
+                                ?new_tip,
+                                ?addr,
+                                err = format!("{err:#}"),
+                                "rejecting invalid tip from peer"
+                            );
+                            if let Some(addr) = addr {
+                                self.ctxt.net.remove_active_peer(addr);
+                            }
+                            false
+                        }
+                    };
                     if let Some(resp_tx) = resp_tx {
                         let () = resp_tx
                             .send(reorg_applied)

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -1283,3 +1283,20 @@ impl Drop for NetTaskHandle {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, is_fatal_reorg_error};
+    use crate::state;
+
+    #[test]
+    fn invalid_peer_block_is_not_fatal() {
+        let err = Error::State(Box::new(state::Error::NotEnoughValueIn));
+        assert!(!is_fatal_reorg_error(&err));
+    }
+
+    #[test]
+    fn infrastructure_error_is_fatal() {
+        assert!(is_fatal_reorg_error(&Error::PeerInfoRxClosed));
+    }
+}


### PR DESCRIPTION
A single block from a peer that fails consensus validation permanently kills the net task, taking the node's networking fully offline.

In the `NewTipReady` handler, `reorg_to_tip(...)?` propagates any error out of `run()`:

```rust
let reorg_applied = task::block_in_place(|| {
    reorg_to_tip(&self.ctxt.env, &self.ctxt.archive,
                 &self.ctxt.mempool, &self.ctxt.state,
                 #[cfg(feature = "zmq")] &self.ctxt.zmq_pub_handler,
                 new_tip)
})?;
```

`run()`'s caller only logs the error and lets the task end:

```rust
if let Err(err) = task.run().await {
    tracing::error!("Net task error: {err:#}");
}
```

So when a peer sends a block whose body fails state validation e.g. a transaction with `value out > value in`, surfacing as `state error: value in is less than value out` (`NotEnoughValueIn`) the whole net task dies. After that nothing services peer connections, producing an endless stream of `Failed to send peer connection info` and `Failed to send response info`. The offending peer isn't even dropped (`addr` is discarded).

This means any peer can permanently disable a node's networking with one invalid block (remote DoS), and any genuine consensus disagreement bricks the node instead of just rejecting that chain.

## Fix

Classify reorg errors. A `State` error is caused by a peer's invalid block and must not be fatal: log a warning, drop the offending peer, and keep running. All other errors (db / env / net infrastructure) still propagate.

`reorg_to_tip` only commits its write txn on success, so on the error path the pre-reorg tip is left intact and continuing is safe.

---

Related PR: https://github.com/LayerTwo-Labs/thunder-rust/pull/102

Note: Both issues were reported by BTCapsule in drivechain telegram group: https://t.me/c/1378593808/234819